### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <h3 align="left">Connect with me:</h3>
 <p align="left">
 <a href="https://twitter.com/developmentcats" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="developmentcats" height="30" width="40" /></a>
-<a href="https://discord.gg/https://discord.gg/TKbReWmBqe" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/discord.svg" alt="https://discord.gg/TKbReWmBqe" height="30" width="40" /></a>
+<a href="https://discord.gg/TKbReWmBqe" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/discord.svg" alt="https://discord.gg/TKbReWmBqe" height="30" width="40" /></a>
 </p>
 
 <h3 align="left">Languages and Tools:</h3>


### PR DESCRIPTION
Correct Discord URL, accidental doubling of 
"https://discord.gg/"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed the Discord invite link in the README to ensure it directs users to the correct server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->